### PR TITLE
New pileup methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-PREFIX = /usr/local/bin #This can be changed"
+prefix= /usr/local/bin #This can be changed"
 CC = gcc
 OPTS = -Wall -g -O3
 
-OBJS = alignmentHeap.o bloomFilter.o graph.o murmur3.o TargetCreator.o realigner.o SemiGlobal.o threads.o
+OBJS = pileup.o
 
 .PHONY: all clean htslib install clean-all
 
@@ -11,13 +11,13 @@ OBJS = alignmentHeap.o bloomFilter.o graph.o murmur3.o TargetCreator.o realigner
 all: PileOMeth
 
 .c.o:
-	$(CC) -c $(OPTS) -I$(INCLUDE_DIRS) $< -o $@
+	$(CC) -c $(OPTS) -Ihtslib $< -o $@
 
 htslib: 
 	$(MAKE) -C htslib
 
-PileOMeth: htslib
-	$(CC) $(OPTS) -Ihtslib -o PileOMeth bed.c PileOMeth.c htslib/libhts.a -lz -lpthread
+PileOMeth: htslib $(OBJS)
+	$(CC) $(OPTS) -Ihtslib -o PileOMeth bed.c PileOMeth.c htslib/libhts.a pileup.o -lz -lpthread
 
 clean:
 	rm -f *.o PileOMeth
@@ -26,4 +26,4 @@ clean-all: clean
 	make --directory=htslib clean
 
 install: PileOMeth
-	install PileOMeth $(PREFIX)
+	install PileOMeth $(prefix)

--- a/PileOMeth.c
+++ b/PileOMeth.c
@@ -179,7 +179,7 @@ void extractCalls(Config *config) {
     iter = bam_mplp_init(1, filter_func, (void **) &data);
     bam_mplp_init_overlaps(iter);
     bam_mplp_set_maxcnt(iter, config->maxDepth);
-    while((ret = bam_mplp_auto(iter, &tid, &pos, &n_plp, plp)) > 0) {
+    while((ret = cust_mplp_auto(iter, &tid, &pos, &n_plp, plp)) > 0) {
         //Do we need to process this position?
 	if (config->reg){
 	    beg0 = data->iter->beg, end0 = data->iter->end;

--- a/PileOMeth.c
+++ b/PileOMeth.c
@@ -218,6 +218,8 @@ void extractCalls(Config *config) {
         nmethyl = nunmethyl = 0;
         base = *(seq+pos);
         for(i=0; i<n_plp; i++) {
+            if(plp[0][i].is_del) continue;
+            if(plp[0][i].is_refskip) continue;
             if(config->bed) if(!readStrandOverlapsBED(plp[0][i].b, config->bed->region[idxBED])) continue;
             if(getStrand((plp[0]+i)->b) & 1) {
                 if(base != 'C' && base != 'c') continue;

--- a/PileOMeth.h
+++ b/PileOMeth.h
@@ -85,3 +85,6 @@ int readStrandOverlapsBED(bam1_t *b, bedRegion region);
 void sortBED(bedRegions *regions);
 void destroyBED(bedRegions *regions);
 bedRegions *parseBED(char *fn, bam_hdr_t *hdr);
+
+//pileup.c
+int cust_mplp_auto(bam_mplp_t iter, int *_tid, int *_pos, int *n_plp, const bam_pileup1_t **plp);

--- a/README.md
+++ b/README.md
@@ -32,6 +32,5 @@ To do list
 ==========
 
  * Enable trimming based on M-bias
- * The -D option seems to only be approximate. Is this an htslib issue?
  * Is the output format the most convenient (it's what Bison uses, so converters have already been written)? It makes more sense to output a predefined VCF format, which would allow processing multiple samples at once. This would require a spec., which should have pretty broad input.
  * Need to finish restructuring things to allow easy library incorporation

--- a/pileup.c
+++ b/pileup.c
@@ -1,0 +1,300 @@
+#include <inttypes.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <assert.h>
+#include "htslib/khash.h"
+#include "htslib/sam.h"
+
+/*
+wtf is g_cstate_null?!?!
+*/
+
+int getStrand(bam1_t *b);
+
+/**********************************************
+* Everything below here needs to track htslib!
+**********************************************/
+typedef struct {
+    int k, x, y, end;
+} cstate_t;
+
+static cstate_t g_cstate_null = { -1, 0, 0, 0 };
+
+typedef struct __linkbuf_t {
+    bam1_t b;
+    int32_t beg, end;
+    cstate_t s;
+    struct __linkbuf_t *next;
+} lbnode_t;
+
+typedef struct {
+    int cnt, n, max;
+    lbnode_t **buf;
+} mempool_t;
+
+// Dictionary of overlapping reads
+KHASH_MAP_INIT_STR(olap_hash, lbnode_t *)
+typedef khash_t(olap_hash) olap_hash_t;
+
+struct __bam_plp_t {
+    mempool_t *mp;
+    lbnode_t *head, *tail, *dummy;
+    int32_t tid, pos, max_tid, max_pos;
+    int is_eof, max_plp, error, maxcnt;
+    uint64_t id;
+    bam_pileup1_t *plp;
+    // for the "auto" interface only
+    bam1_t *b;
+    bam_plp_auto_f func;
+    void *data;
+    olap_hash_t *overlaps;
+};
+
+struct __bam_mplp_t {
+    int n;
+    uint64_t min, *pos;
+    bam_plp_t *iter;
+    int *n_plp;
+    const bam_pileup1_t **plp;
+};
+
+static inline lbnode_t *mp_alloc(mempool_t *mp)
+{
+    ++mp->cnt;
+    if (mp->n == 0) return (lbnode_t*)calloc(1, sizeof(lbnode_t));
+    else return mp->buf[--mp->n];
+}
+
+/**********************************************
+* Done reinventing the wheel
+**********************************************/
+//This is from bison
+int32_t *calculate_positions(bam1_t *read) {
+    int32_t *positions = malloc(sizeof(int32_t) * (size_t)read->core.l_qseq);
+    int i, j, offset = 0, op, op_len;
+    uint32_t *CIGAR = bam_get_cigar(read);
+    int32_t previous_position = read->core.pos;
+
+    for(i=0; i<read->core.n_cigar; i++) {
+        op = bam_cigar_op(*(CIGAR+i));
+        op_len = bam_cigar_oplen(*(CIGAR+i));
+        for(j=0; j<op_len; j++) {
+            if(op == 0 || op == 7 || op == 8) { //M, =, X
+                *(positions+offset) = previous_position++;
+                offset++;
+            } else if(op == 1 || op == 4 || op == 5) { //I, S, H
+                *(positions+offset) = -1;
+                offset++;
+            } else if(op == 2 || op == 3) { //D, N
+                previous_position++;
+            } else { //P
+                printf("We encountered a CIGAR operation that we're not ready to deal with in %s\n", bam_get_qname(read));
+            }
+        }
+    }
+    return positions;
+}
+
+static void cust_tweak_overlap_quality(bam1_t *a, bam1_t *b) {
+    int ia = 0, ib = 0;
+    int32_t na = a->core.l_qseq, nb = b->core.l_qseq;
+    int32_t *posa = calculate_positions(a);
+    int32_t *posb = calculate_positions(b);
+    uint8_t *a_qual = bam_get_qual(a), *b_qual = bam_get_qual(b);
+    uint8_t *a_seq  = bam_get_seq(a), *b_seq = bam_get_seq(b);
+
+    //If alignments are on opposite strands then exit
+    if((getStrand(a) | getStrand(b)) == 3) goto quit;
+
+    //Go to the first mapped position
+    while(posa[ia]<0 && ia<na) ia++;
+    while(posa[ib]<0 && ib<nb) ib++;
+    if(ia==na || ib==nb) goto quit;
+
+    //Go to the first overlapping position
+    if(posa[ia]<posb[ib]) {
+        while(posa[ia]<posb[ib] && ia<na) ia++;
+    } else {
+        while(posb[ib]<posa[ia] && ib<nb) ib++;
+    }
+    if(ia==na || ib==nb) goto quit;
+
+    //Take care of the overlap
+    while(ia<na && ib<nb) {
+        if(posa[ia] < posb[ib] || posa[ia] < 0) {
+            ia++;
+            continue;
+        }
+        if(posb[ib] < posa[ia] || posb[ib] < 0) {
+            ib++;
+            continue;
+        }
+        if(bam_seqi(a_seq, ia) != bam_seqi(b_seq, ib)) {
+            if(a_qual[ia]>b_qual[ib] && bam_seqi(a_seq,ia) != 15) {
+                a_qual[ia] -= b_qual[ib];
+                b_qual[ib] = 0;
+            } else if(b_qual[ib]>a_qual[ia] && bam_seqi(b_seq,ib) != 15) {
+                b_qual[ib] -= a_qual[ia];
+                a_qual[ia] = 0;
+            } else {
+                a_qual[ia] = 0;
+                b_qual[ib] = 0;
+            }
+        } else {
+            if(a_qual[ia]>b_qual[ib]) {
+                a_qual[ia] += 0.2*a_qual[ia];
+                b_qual[ib] = 0;
+            } else {
+                b_qual[ib] += 0.2*b_qual[ib];
+                a_qual[ia] = 0;
+            }
+        }
+        a_qual[ia] = (a_qual[ia]<=255) ? a_qual[ia] : 255;
+        b_qual[ib] = (b_qual[ib]<=255) ? b_qual[ib] : 255;
+        ia++;
+        ib++;
+    }
+
+quit :
+    free(posa);
+    free(posb);
+}
+
+//This is a modified version of overlap_push()
+static void cust_overlap_push(bam_plp_t iter, lbnode_t *node)
+{
+    if ( !iter->overlaps ) return;
+
+    // mapped mates only
+    if ( node->b.core.flag&BAM_FMUNMAP ) return;
+
+    //If the first read ends before the second begins, then skip
+    if((&node->b)->core.isize > 0) {
+        if(bam_endpos(&node->b) < (&node->b)->core.mpos) return;
+    }
+
+    khiter_t kitr = kh_get(olap_hash, iter->overlaps, bam_get_qname(&node->b));
+    if ( kitr==kh_end(iter->overlaps) )
+    {
+        if((&node->b)->core.isize < 0) return; //The mate should be here, but isn't
+        if((&node->b)->core.tid != (&node->b)->core.mtid) return; //Different chromosomes
+        int ret;
+        kitr = kh_put(olap_hash, iter->overlaps, bam_get_qname(&node->b), &ret);
+        kh_value(iter->overlaps, kitr) = node;
+    }
+    else
+    {
+        lbnode_t *a = kh_value(iter->overlaps, kitr);
+        cust_tweak_overlap_quality(&a->b, &node->b);
+        kh_del(olap_hash, iter->overlaps, kitr);
+        assert(a->end-1 == a->s.end);
+        a->end = a->b.core.pos + bam_cigar2rlen(a->b.core.n_cigar, bam_get_cigar(&a->b));
+        a->s.end = a->end - 1;
+    }
+}
+
+//Essentially overlap_remove()
+static void cust_overlap_remove(bam_plp_t iter, const bam1_t *b) {
+    if(!iter->overlaps) return;
+
+    khiter_t kitr;
+    if(b) {
+        kitr = kh_get(olap_hash, iter->overlaps, bam_get_qname(b));
+        if ( kitr!=kh_end(iter->overlaps) )
+            kh_del(olap_hash, iter->overlaps, kitr);
+    } else {
+        // remove all
+        for (kitr = kh_begin(iter->overlaps); kitr<kh_end(iter->overlaps); kitr++)
+            if ( kh_exist(iter->overlaps, kitr) ) kh_del(olap_hash, iter->overlaps, kitr);
+    }
+}
+
+
+//This is essentially just bam_plp_push()
+int cust_plp_push(bam_plp_t iter, const bam1_t *b)
+{
+    if (iter->error) return -1;
+    if (b) {
+        if (b->core.tid < 0) { cust_overlap_remove(iter, b); return 0; }
+        // Skip only unmapped reads here, any additional filtering must be done in iter->func
+        if (b->core.flag & BAM_FUNMAP) { cust_overlap_remove(iter, b); return 0; }
+        if (iter->tid == b->core.tid && iter->pos == b->core.pos && iter->mp->cnt > iter->maxcnt)
+        {
+            cust_overlap_remove(iter, b);
+            return 0;
+        }
+        bam_copy1(&iter->tail->b, b);
+        cust_overlap_push(iter, iter->tail);
+        iter->tail->beg = b->core.pos;
+        iter->tail->end = b->core.pos + bam_cigar2rlen(b->core.n_cigar, bam_get_cigar(b));
+        iter->tail->s = g_cstate_null; iter->tail->s.end = iter->tail->end - 1; // initialize cstate_t
+        if (b->core.tid < iter->max_tid) {
+            fprintf(stderr, "[bam_pileup_core] the input is not sorted (chromosomes out of order)\n");
+            iter->error = 1;
+            return -1;
+        }
+        if ((b->core.tid == iter->max_tid) && (iter->tail->beg < iter->max_pos)) {
+            fprintf(stderr, "[bam_pileup_core] the input is not sorted (reads out of order)\n");
+            iter->error = 1;
+            return -1;
+        }
+        iter->max_tid = b->core.tid; iter->max_pos = iter->tail->beg;
+        if (iter->tail->end > iter->pos || iter->tail->b.core.tid > iter->tid) {
+            iter->tail->next = mp_alloc(iter->mp);
+            iter->tail = iter->tail->next;
+        }
+    } else iter->is_eof = 1;
+    return 0;
+}
+
+//This is essentially just bam_plp_auto
+const bam_pileup1_t *cust_plp_auto(bam_plp_t iter, int *_tid, int *_pos, int *_n_plp)
+{
+    const bam_pileup1_t *plp;
+    if (iter->func == 0 || iter->error) { *_n_plp = -1; return 0; }
+    if ((plp = bam_plp_next(iter, _tid, _pos, _n_plp)) != 0) return plp;
+    else { // no pileup line can be obtained; read alignments
+        *_n_plp = 0;
+        if (iter->is_eof) return 0;
+        int ret;
+        while ( (ret=iter->func(iter->data, iter->b)) >= 0) {
+            if (cust_plp_push(iter, iter->b) < 0) {
+                *_n_plp = -1;
+                return 0;
+            }
+            if ((plp = bam_plp_next(iter, _tid, _pos, _n_plp)) != 0) return plp;
+            // otherwise no pileup line can be returned; read the next alignment.
+        }
+        if ( ret < -1 ) { iter->error = ret; *_n_plp = -1; return 0; }
+        bam_plp_push(iter, 0);
+        if ((plp = bam_plp_next(iter, _tid, _pos, _n_plp)) != 0) return plp;
+        return 0;
+    }
+}
+
+
+//This is essentially just bam_mplp_auto from htslib
+int cust_mplp_auto(bam_mplp_t iter, int *_tid, int *_pos, int *n_plp, const bam_pileup1_t **plp)
+{
+    int i, ret = 0;
+    uint64_t new_min = (uint64_t)-1;
+    for (i = 0; i < iter->n; ++i) {
+        if (iter->pos[i] == iter->min) {
+            int tid, pos;
+            iter->plp[i] = cust_plp_auto(iter->iter[i], &tid, &pos, &iter->n_plp[i]);
+            if ( iter->iter[i]->error ) return -1;
+            iter->pos[i] = iter->plp[i] ? (uint64_t)tid<<32 | pos : 0;
+        }
+        if (iter->plp[i] && iter->pos[i] < new_min) new_min = iter->pos[i];
+    }
+    iter->min = new_min;
+    if (new_min == (uint64_t)-1) return 0;
+    *_tid = new_min>>32; *_pos = (uint32_t)new_min;
+    for (i = 0; i < iter->n; ++i) {
+        if (iter->pos[i] == iter->min) { // FIXME: valgrind reports "uninitialised value(s) at this line"
+            n_plp[i] = iter->n_plp[i], plp[i] = iter->plp[i];
+            ++ret;
+        } else n_plp[i] = 0, plp[i] = 0;
+    }
+    return ret;
+}

--- a/pileup.c
+++ b/pileup.c
@@ -84,7 +84,7 @@ int32_t *calculate_positions(bam1_t *read) {
             } else if(op == 2 || op == 3) { //D, N
                 previous_position++;
             } else { //P
-                printf("We encountered a CIGAR operation that we're not ready to deal with in %s\n", bam_get_qname(read));
+                fprintf(stderr, "[calculate_positions] We encountered a CIGAR operation that we're not ready to deal with in %s\n", bam_get_qname(read));
             }
         }
     }


### PR DESCRIPTION
This branch reimplements part of the mpileup pathway from HTSlib in a way that overlap trimming should work correctly. This handles discordant alignments and those where one read has been heavily trimmed but there is nonetheless overlap. Note that the actual trimming due to methylation bias needs to happen upstream, in the filter function given to bam_mplp_init() (this is handled in my other pull request).

BTW, the down side to this is obviously that parts of htslib are just copied over. The API doesn't allow for any sort of custom functions other than for filtering, so the only alternative to the current method would be to completely reimplement the pileup methods (this would seem overkill). Tracking changes should be pretty simple in comparison.