### PR TITLE
Merge Context Error

### DIFF
--- a/R/mergeResults.R
+++ b/R/mergeResults.R
@@ -30,11 +30,8 @@ getMethAndCounts <- function(bamFiles, minSamples=NULL, exptName="tabulated"){
   methRanges <- GRangesList(mclapply(methFiles, import, selection=coords))
   meths <- do.call(cbind, lapply(methRanges, function(mr) mr$score))
   rownames(meths) <- paste0(seqnames(coords), ":", start(coords))
-
-  ## reorder to match input file order...
   counts <- counts[ , names(countFiles) ]
   meths <- meths[ , names(countFiles) ]
-
   stopifnot(identical(colnames(meths), colnames(counts)))
   write.table(meths, paste(exptName, "methylation", "txt", sep="."))
   write.table(counts, paste(exptName, "counts", "txt", sep="."))

--- a/R/mergeResults.R
+++ b/R/mergeResults.R
@@ -1,0 +1,38 @@
+library(rtracklayer)
+
+## ideally, we'd like to do something along the lines of:
+##
+##   res <- mergeResults(BAMfiles, mode="union", minCounts=5, how="perGroup") 
+##
+## or something along those lines.  Then the same code in Python or R would
+## do the same thing by wrapping PileOMeth and running through the same list.
+##
+BAMfiles <- list.files(patt=".bam$")
+
+## later on, we'll want to generate these in-flight from BAMs, using PileOMeth
+## for now, just open them up 
+##
+options("mc.cores"=4)
+getMethAndCounts <- function(bamFiles, minSamples=NULL, exptName="tabulated"){
+  library(parallel)
+  if (is.null(minSamples)) minSamples <- length(bamFiles)
+  countFiles <- sub(".bam$", "_CpG.counts.bw", bamFiles)
+  names(countFiles) <- sapply(countFiles, function(x) strsplit(x,"\\.")[[1]][1])
+  names(countFiles) <- gsub("-", "_", names(countFiles))
+  countRanges <- GRangesList(mclapply(countFiles, import))
+  coords <- sort(unname(unique(unlist(countRanges))))
+  coords <- coords[ countOverlaps(coords, countRanges) >= minSamples ]
+  counts <- do.call(cbind,
+                    lapply(countRanges, 
+                           function(cr) subsetByOverlaps(cr, coords)$score))
+  rownames(counts) <- paste0(seqnames(coords), ":", start(coords))
+  methFiles <- sub(".bam$", "_CpG.meth.bw", BAMfiles)
+  methRanges <- GRangesList(mclapply(methFiles, import, selection=coords))
+  meths <- do.call(cbind, lapply(methRanges, function(mr) mr$score))
+  rownames(meths) <- paste0(seqnames(coords), ":", start(coords))
+
+  stopifnot(identical(colnames(meths), colnames(counts)))
+  write.table(meths, paste(exptName, "methylation", "txt", sep="."))
+  write.table(counts, paste(exptName, "counts", "txt", sep="."))
+  invisible(list(counts=counts, methylation=meths))
+}

--- a/R/mergeResults.R
+++ b/R/mergeResults.R
@@ -31,7 +31,10 @@ getMethAndCounts <- function(bamFiles, minSamples=NULL, exptName="tabulated"){
   meths <- do.call(cbind, lapply(methRanges, function(mr) mr$score))
   rownames(meths) <- paste0(seqnames(coords), ":", start(coords))
 
-  stopifnot(identical(colnames(meths), colnames(counts)))
+  ## reorder to match input file order...
+  counts <- counts[ , names(countFiles) ]
+  meths <- meths[ , names(countFiles) ]
+
   write.table(meths, paste(exptName, "methylation", "txt", sep="."))
   write.table(counts, paste(exptName, "counts", "txt", sep="."))
   invisible(list(counts=counts, methylation=meths))

--- a/R/mergeResults.R
+++ b/R/mergeResults.R
@@ -26,7 +26,7 @@ getMethAndCounts <- function(bamFiles, minSamples=NULL, exptName="tabulated"){
                     lapply(countRanges, 
                            function(cr) subsetByOverlaps(cr, coords)$score))
   rownames(counts) <- paste0(seqnames(coords), ":", start(coords))
-  methFiles <- sub(".bam$", "_CpG.meth.bw", BAMfiles)
+  methFiles <- sub("_CpG.counts.bw", "_CpG.meth.bw", countFiles)
   methRanges <- GRangesList(mclapply(methFiles, import, selection=coords))
   meths <- do.call(cbind, lapply(methRanges, function(mr) mr$score))
   rownames(meths) <- paste0(seqnames(coords), ":", start(coords))
@@ -35,6 +35,7 @@ getMethAndCounts <- function(bamFiles, minSamples=NULL, exptName="tabulated"){
   counts <- counts[ , names(countFiles) ]
   meths <- meths[ , names(countFiles) ]
 
+  stopifnot(identical(colnames(meths), colnames(counts)))
   write.table(meths, paste(exptName, "methylation", "txt", sep="."))
   write.table(counts, paste(exptName, "counts", "txt", sep="."))
   invisible(list(counts=counts, methylation=meths))


### PR DESCRIPTION
The merge context feature creates repeated start and end points, sometimes with different values. Additionally, some of the values from the merged context differ from that of the unmerged context when values were already spaced such that the merge should not have changed the methylation fractions. Look to images

![merged](https://cloud.githubusercontent.com/assets/6854102/8727613/7c254cba-2b95-11e5-8b62-d1def73c5f0e.png)

![unmerged](https://cloud.githubusercontent.com/assets/6854102/8727630/927378fc-2b95-11e5-993e-8072412cc5d9.png)
